### PR TITLE
Add FPS monitor via rosout

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ To run all the ros nodes at the same time you can use the `autonomy.launch` laun
 roslaunch autonomy autonomy.launch
 ```
 
+## Node monitoring
+
+There is a helper script that prints CPU and memory usage for all running ROS
+nodes. This can be useful when debugging performance issues.
+
+```bash
+rosrun autonomy node_monitor.py
+```
+The update rate can be changed with the `~interval` parameter (seconds).
+
+## CV publisher framerate
+
+To estimate the frame rate of the `cv_publishers` node from log messages you can
+use the helper script below:
+
+```bash
+rosrun autonomy fps_from_logs.py
+```
+The window size for averaging can be customised with the `~window_size`
+parameter.
+
 
 ## Download ROS Bags
 

--- a/autonomy/package.xml
+++ b/autonomy/package.xml
@@ -25,6 +25,7 @@
     <depend>rosbag</depend>
     <depend>std_msgs</depend>
     <depend>topic_tools</depend>
+    <exec_depend>python3-psutil</exec_depend>
 
 
 </package>

--- a/autonomy/scripts/analytics/fps_from_logs.py
+++ b/autonomy/scripts/analytics/fps_from_logs.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Estimate FPS from cv_publishers log messages.
+
+This script subscribes to /rosout and looks for log messages from the
+cv_publishers node that contain "Received RGB image message".
+It calculates a rolling FPS over a configurable window of messages.
+"""
+import collections
+import rospy
+from rosgraph_msgs.msg import Log
+
+
+class FPSMonitor:
+    def __init__(self, window_size: int = 30) -> None:
+        self.window = collections.deque(maxlen=window_size)
+
+    def callback(self, msg: Log) -> None:
+        if msg.name.endswith("cv_publihser") and "Received RGB image message" in msg.msg:
+            now = rospy.Time.now()
+            self.window.append(now)
+            if len(self.window) >= 2:
+                elapsed = (self.window[-1] - self.window[0]).to_sec()
+                if elapsed > 0:
+                    fps = (len(self.window) - 1) / elapsed
+                    rospy.loginfo(f"Approx FPS: {fps:.2f}")
+
+
+def main() -> None:
+    rospy.init_node("cv_fps_from_logs", anonymous=True)
+    window_size = rospy.get_param("~window_size", 30)
+    monitor = FPSMonitor(window_size)
+    rospy.Subscriber("/rosout", Log, monitor.callback)
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()

--- a/autonomy/scripts/analytics/node_monitor.py
+++ b/autonomy/scripts/analytics/node_monitor.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""ROS node resource monitor.
+
+This script periodically logs CPU and memory usage for all running ROS nodes.
+"""
+import subprocess
+import time
+from typing import Dict, Optional
+
+import psutil
+import rospy
+
+
+def get_nodes() -> list:
+    try:
+        output = subprocess.check_output(["rosnode", "list"], text=True)
+        return [n for n in output.splitlines() if n]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def get_pid(node: str) -> Optional[int]:
+    try:
+        output = subprocess.check_output(["rosnode", "info", node], text=True)
+    except subprocess.CalledProcessError:
+        return None
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Pid:"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return None
+    return None
+
+
+def monitor(interval: float = 1.0) -> None:
+    rospy.init_node("ros_node_monitor", anonymous=True)
+    last_cpu: Dict[int, float] = {}
+    rate = rospy.Rate(1 / interval if interval > 0 else 1)
+    while not rospy.is_shutdown():
+        for node in get_nodes():
+            pid = get_pid(node)
+            if pid is None:
+                continue
+            try:
+                proc = psutil.Process(pid)
+            except psutil.NoSuchProcess:
+                continue
+            cpu = proc.cpu_percent(interval=None)
+            mem = proc.memory_info().rss / (1024 * 1024)
+            rospy.loginfo(f"{node}: CPU {cpu:.2f}% MEM {mem:.2f} MB")
+        rate.sleep()
+
+
+if __name__ == "__main__":
+    interval = rospy.get_param("~interval", 1.0)
+    monitor(interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-
 opencv-python
 uvicorn
 fastapi
 matplotlib
+psutil


### PR DESCRIPTION
## Summary
- add script `fps_from_logs.py` to estimate frame rate from ROS logs
- document framerate monitor in README

## Testing
- `find autonomy -name '*.py' | xargs python3 -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6847c22f4d1883259d86b26f03216d42